### PR TITLE
fix zephyr header include

### DIFF
--- a/i2c/sensirion_i2c_hal.c
+++ b/i2c/sensirion_i2c_hal.c
@@ -31,7 +31,7 @@
 
 #include "sensirion_i2c_hal.h"
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/i2c.h>
 


### PR DESCRIPTION
zephyr/zephyr.h is deprecated, use zephyr/kernel.h